### PR TITLE
refactor(api): migrate from models to dto package and enhance user authentication

### DIFF
--- a/api/handlers/user_handlers.go
+++ b/api/handlers/user_handlers.go
@@ -171,4 +171,3 @@ func (h *CheckHasParentIDHandler) HandleGin(c *gin.Context) {
 
 	response.OK(c, gin.H{"has_parent_id": hasParentID}, "Success")
 }
-

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -35,7 +35,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.AddCategoryRequest"
+                            "$ref": "#/definitions/dto.CategoryRequest"
                         }
                     }
                 ],
@@ -43,25 +43,25 @@ const docTemplate = `{
                     "201": {
                         "description": "Category added successfully",
                         "schema": {
-                            "$ref": "#/definitions/gin.Response"
+                            "$ref": "#/definitions/dto.Response"
                         }
                     },
                     "400": {
                         "description": "Validation error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Category already exists",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -83,14 +83,14 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.CategoryResponse"
+                                "$ref": "#/definitions/dto.CategoryResponse"
                             }
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -124,14 +124,14 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.CategoryResponse"
+                                "$ref": "#/definitions/dto.CategoryResponse"
                             }
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -169,7 +169,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.AddDeviceRequest"
+                            "$ref": "#/definitions/dto.DeviceRequest"
                         }
                     }
                 ],
@@ -177,25 +177,25 @@ const docTemplate = `{
                     "201": {
                         "description": "Device added successfully",
                         "schema": {
-                            "$ref": "#/definitions/gin.Response"
+                            "$ref": "#/definitions/dto.Response"
                         }
                     },
                     "400": {
                         "description": "Validation error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "User not authenticated",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -221,7 +221,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.AttachIotPolicyRequest"
+                            "$ref": "#/definitions/dto.PolicyAttachRequest"
                         }
                     }
                 ],
@@ -229,19 +229,19 @@ const docTemplate = `{
                     "200": {
                         "description": "IoT policy attached successfully",
                         "schema": {
-                            "$ref": "#/definitions/gin.Response"
+                            "$ref": "#/definitions/dto.Response"
                         }
                     },
                     "400": {
                         "description": "Invalid request or validation error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Failed to attach IoT policy",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -267,7 +267,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.GetDeviceSensorDataRequest"
+                            "$ref": "#/definitions/dto.SensorDataRequest"
                         }
                     }
                 ],
@@ -275,19 +275,34 @@ const docTemplate = `{
                     "200": {
                         "description": "Sensor data for the device",
                         "schema": {
-                            "$ref": "#/definitions/models.GetDeviceSensorDataResponse"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/dto.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/dto.SensorDataResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "400": {
                         "description": "Invalid request or validation error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -298,6 +313,9 @@ const docTemplate = `{
                 "description": "Checks if the authenticated user has a parent ID set in their profile",
                 "produces": [
                     "application/json"
+                ],
+                "tags": [
+                    "User Management"
                 ],
                 "summary": "Check if user has parent ID",
                 "parameters": [
@@ -342,9 +360,20 @@ const docTemplate = `{
         },
         "/user/details": {
             "get": {
-                "description": "Retrieves the user details for the authenticated user",
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieve authenticated user's profile information",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
+                ],
+                "tags": [
+                    "User Management"
                 ],
                 "summary": "Get user details",
                 "parameters": [
@@ -358,39 +387,58 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "No user details found (null response)",
+                        "description": "User details retrieved successfully",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/dto.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/dto.UserResponse"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "401": {
-                        "description": "Error when user is not authenticated",
+                        "description": "User not authenticated",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "User not found",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
-                        "description": "Error when retrieving user details fails",
+                        "description": "Internal server error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
             },
             "post": {
-                "description": "Updates or adds user details for the authenticated user",
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Update the authenticated user's profile information",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
                     "application/json"
+                ],
+                "tags": [
+                    "User Management"
                 ],
                 "summary": "Update user details",
                 "parameters": [
@@ -402,12 +450,12 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "User details information",
-                        "name": "request",
+                        "description": "User details",
+                        "name": "user",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.UserDetailsRequest"
+                            "$ref": "#/definitions/dto.UserDetailsRequest"
                         }
                     }
                 ],
@@ -415,35 +463,37 @@ const docTemplate = `{
                     "200": {
                         "description": "User details updated successfully",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/dto.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/dto.UserResponse"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "400": {
-                        "description": "Error when request validation fails",
+                        "description": "Validation error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "401": {
-                        "description": "Error when user is not authenticated",
+                        "description": "User not authenticated",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
-                        "description": "Error when updating user details fails",
+                        "description": "Internal server error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -482,20 +532,20 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.DeviceResponse"
+                                "$ref": "#/definitions/dto.DeviceResponse"
                             }
                         }
                     },
                     "401": {
                         "description": "User not authenticated",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -503,42 +553,30 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "gin.ErrorResponse": {
-            "description": "Standard API error response format",
+        "dto.AddressOutput": {
             "type": "object",
             "properties": {
-                "message": {
-                    "description": "Error message",
-                    "type": "string",
-                    "example": "Something went wrong"
+                "city": {
+                    "type": "string"
                 },
-                "status": {
-                    "description": "Always false for errors",
-                    "type": "boolean",
-                    "example": false
+                "country": {
+                    "type": "string"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "street1": {
+                    "type": "string"
+                },
+                "street2": {
+                    "type": "string"
+                },
+                "zip": {
+                    "type": "string"
                 }
             }
         },
-        "gin.Response": {
-            "description": "Standard API success response format",
-            "type": "object",
-            "properties": {
-                "data": {
-                    "description": "Optional data payload"
-                },
-                "message": {
-                    "description": "Optional success message",
-                    "type": "string",
-                    "example": "Operation successful"
-                },
-                "status": {
-                    "description": "Indicates success status",
-                    "type": "boolean",
-                    "example": true
-                }
-            }
-        },
-        "models.AddCategoryRequest": {
+        "dto.CategoryRequest": {
             "type": "object",
             "required": [
                 "name",
@@ -557,13 +595,33 @@ const docTemplate = `{
                 }
             }
         },
-        "models.AddDeviceRequest": {
+        "dto.CategoryResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.DeviceRequest": {
             "type": "object",
             "required": [
                 "deviceId",
                 "deviceName"
             ],
             "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
                 "deviceId": {
                     "type": "string",
                     "maxLength": 50,
@@ -576,7 +634,41 @@ const docTemplate = `{
                 }
             }
         },
-        "models.AttachIotPolicyRequest": {
+        "dto.DeviceResponse": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "deviceId": {
+                    "type": "string"
+                },
+                "deviceName": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "dto.PolicyAttachRequest": {
             "type": "object",
             "required": [
                 "identityId"
@@ -587,32 +679,22 @@ const docTemplate = `{
                 }
             }
         },
-        "models.CategoryResponse": {
+        "dto.Response": {
             "type": "object",
             "properties": {
-                "name": {
+                "data": {},
+                "error": {
                     "type": "string"
                 },
-                "type": {
+                "message": {
                     "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
                 }
             }
         },
-        "models.DeviceResponse": {
-            "type": "object",
-            "properties": {
-                "device_name": {
-                    "type": "string"
-                },
-                "mac_address": {
-                    "type": "string"
-                },
-                "user_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "models.GetDeviceSensorDataRequest": {
+        "dto.SensorDataRequest": {
             "type": "object",
             "required": [
                 "dateMode",
@@ -638,18 +720,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.GetDeviceSensorDataResponse": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.SensorData"
-                    }
-                }
-            }
-        },
-        "models.SensorData": {
+        "dto.SensorDataResponse": {
             "type": "object",
             "properties": {
                 "amperage": {
@@ -666,42 +737,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.UserDetails": {
-            "type": "object",
-            "properties": {
-                "city": {
-                    "type": "string"
-                },
-                "country": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "firstName": {
-                    "type": "string"
-                },
-                "lastName": {
-                    "type": "string"
-                },
-                "phone": {
-                    "type": "string"
-                },
-                "region": {
-                    "type": "string"
-                },
-                "street1": {
-                    "type": "string"
-                },
-                "street2": {
-                    "type": "string"
-                },
-                "zip": {
-                    "type": "string"
-                }
-            }
-        },
-        "models.UserDetailsRequest": {
+        "dto.UserDetailsRequest": {
             "type": "object",
             "required": [
                 "city",
@@ -730,6 +766,9 @@ const docTemplate = `{
                 "lastName": {
                     "type": "string"
                 },
+                "parentId": {
+                    "type": "string"
+                },
                 "phone": {
                     "type": "string"
                 },
@@ -743,6 +782,35 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "zip": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.UserResponse": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "$ref": "#/definitions/dto.AddressOutput"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "firstName": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "parentId": {
+                    "type": "string"
+                },
+                "phone": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -24,7 +24,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.AddCategoryRequest"
+                            "$ref": "#/definitions/dto.CategoryRequest"
                         }
                     }
                 ],
@@ -32,25 +32,25 @@
                     "201": {
                         "description": "Category added successfully",
                         "schema": {
-                            "$ref": "#/definitions/gin.Response"
+                            "$ref": "#/definitions/dto.Response"
                         }
                     },
                     "400": {
                         "description": "Validation error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Category already exists",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -72,14 +72,14 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.CategoryResponse"
+                                "$ref": "#/definitions/dto.CategoryResponse"
                             }
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -113,14 +113,14 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.CategoryResponse"
+                                "$ref": "#/definitions/dto.CategoryResponse"
                             }
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -158,7 +158,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.AddDeviceRequest"
+                            "$ref": "#/definitions/dto.DeviceRequest"
                         }
                     }
                 ],
@@ -166,25 +166,25 @@
                     "201": {
                         "description": "Device added successfully",
                         "schema": {
-                            "$ref": "#/definitions/gin.Response"
+                            "$ref": "#/definitions/dto.Response"
                         }
                     },
                     "400": {
                         "description": "Validation error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "User not authenticated",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -210,7 +210,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.AttachIotPolicyRequest"
+                            "$ref": "#/definitions/dto.PolicyAttachRequest"
                         }
                     }
                 ],
@@ -218,19 +218,19 @@
                     "200": {
                         "description": "IoT policy attached successfully",
                         "schema": {
-                            "$ref": "#/definitions/gin.Response"
+                            "$ref": "#/definitions/dto.Response"
                         }
                     },
                     "400": {
                         "description": "Invalid request or validation error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Failed to attach IoT policy",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -256,7 +256,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.GetDeviceSensorDataRequest"
+                            "$ref": "#/definitions/dto.SensorDataRequest"
                         }
                     }
                 ],
@@ -264,19 +264,34 @@
                     "200": {
                         "description": "Sensor data for the device",
                         "schema": {
-                            "$ref": "#/definitions/models.GetDeviceSensorDataResponse"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/dto.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/dto.SensorDataResponse"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "400": {
                         "description": "Invalid request or validation error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -287,6 +302,9 @@
                 "description": "Checks if the authenticated user has a parent ID set in their profile",
                 "produces": [
                     "application/json"
+                ],
+                "tags": [
+                    "User Management"
                 ],
                 "summary": "Check if user has parent ID",
                 "parameters": [
@@ -331,9 +349,20 @@
         },
         "/user/details": {
             "get": {
-                "description": "Retrieves the user details for the authenticated user",
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieve authenticated user's profile information",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
+                ],
+                "tags": [
+                    "User Management"
                 ],
                 "summary": "Get user details",
                 "parameters": [
@@ -347,39 +376,58 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No user details found (null response)",
+                        "description": "User details retrieved successfully",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/dto.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/dto.UserResponse"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "401": {
-                        "description": "Error when user is not authenticated",
+                        "description": "User not authenticated",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "User not found",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
-                        "description": "Error when retrieving user details fails",
+                        "description": "Internal server error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
             },
             "post": {
-                "description": "Updates or adds user details for the authenticated user",
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Update the authenticated user's profile information",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
                     "application/json"
+                ],
+                "tags": [
+                    "User Management"
                 ],
                 "summary": "Update user details",
                 "parameters": [
@@ -391,12 +439,12 @@
                         "required": true
                     },
                     {
-                        "description": "User details information",
-                        "name": "request",
+                        "description": "User details",
+                        "name": "user",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.UserDetailsRequest"
+                            "$ref": "#/definitions/dto.UserDetailsRequest"
                         }
                     }
                 ],
@@ -404,35 +452,37 @@
                     "200": {
                         "description": "User details updated successfully",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/dto.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/dto.UserResponse"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "400": {
-                        "description": "Error when request validation fails",
+                        "description": "Validation error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "401": {
-                        "description": "Error when user is not authenticated",
+                        "description": "User not authenticated",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
-                        "description": "Error when updating user details fails",
+                        "description": "Internal server error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -471,20 +521,20 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.DeviceResponse"
+                                "$ref": "#/definitions/dto.DeviceResponse"
                             }
                         }
                     },
                     "401": {
                         "description": "User not authenticated",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/gin.ErrorResponse"
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     }
                 }
@@ -492,42 +542,30 @@
         }
     },
     "definitions": {
-        "gin.ErrorResponse": {
-            "description": "Standard API error response format",
+        "dto.AddressOutput": {
             "type": "object",
             "properties": {
-                "message": {
-                    "description": "Error message",
-                    "type": "string",
-                    "example": "Something went wrong"
+                "city": {
+                    "type": "string"
                 },
-                "status": {
-                    "description": "Always false for errors",
-                    "type": "boolean",
-                    "example": false
+                "country": {
+                    "type": "string"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "street1": {
+                    "type": "string"
+                },
+                "street2": {
+                    "type": "string"
+                },
+                "zip": {
+                    "type": "string"
                 }
             }
         },
-        "gin.Response": {
-            "description": "Standard API success response format",
-            "type": "object",
-            "properties": {
-                "data": {
-                    "description": "Optional data payload"
-                },
-                "message": {
-                    "description": "Optional success message",
-                    "type": "string",
-                    "example": "Operation successful"
-                },
-                "status": {
-                    "description": "Indicates success status",
-                    "type": "boolean",
-                    "example": true
-                }
-            }
-        },
-        "models.AddCategoryRequest": {
+        "dto.CategoryRequest": {
             "type": "object",
             "required": [
                 "name",
@@ -546,13 +584,33 @@
                 }
             }
         },
-        "models.AddDeviceRequest": {
+        "dto.CategoryResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.DeviceRequest": {
             "type": "object",
             "required": [
                 "deviceId",
                 "deviceName"
             ],
             "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
                 "deviceId": {
                     "type": "string",
                     "maxLength": 50,
@@ -565,7 +623,41 @@
                 }
             }
         },
-        "models.AttachIotPolicyRequest": {
+        "dto.DeviceResponse": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "deviceId": {
+                    "type": "string"
+                },
+                "deviceName": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "dto.PolicyAttachRequest": {
             "type": "object",
             "required": [
                 "identityId"
@@ -576,32 +668,22 @@
                 }
             }
         },
-        "models.CategoryResponse": {
+        "dto.Response": {
             "type": "object",
             "properties": {
-                "name": {
+                "data": {},
+                "error": {
                     "type": "string"
                 },
-                "type": {
+                "message": {
                     "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
                 }
             }
         },
-        "models.DeviceResponse": {
-            "type": "object",
-            "properties": {
-                "device_name": {
-                    "type": "string"
-                },
-                "mac_address": {
-                    "type": "string"
-                },
-                "user_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "models.GetDeviceSensorDataRequest": {
+        "dto.SensorDataRequest": {
             "type": "object",
             "required": [
                 "dateMode",
@@ -627,18 +709,7 @@
                 }
             }
         },
-        "models.GetDeviceSensorDataResponse": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.SensorData"
-                    }
-                }
-            }
-        },
-        "models.SensorData": {
+        "dto.SensorDataResponse": {
             "type": "object",
             "properties": {
                 "amperage": {
@@ -655,42 +726,7 @@
                 }
             }
         },
-        "models.UserDetails": {
-            "type": "object",
-            "properties": {
-                "city": {
-                    "type": "string"
-                },
-                "country": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "firstName": {
-                    "type": "string"
-                },
-                "lastName": {
-                    "type": "string"
-                },
-                "phone": {
-                    "type": "string"
-                },
-                "region": {
-                    "type": "string"
-                },
-                "street1": {
-                    "type": "string"
-                },
-                "street2": {
-                    "type": "string"
-                },
-                "zip": {
-                    "type": "string"
-                }
-            }
-        },
-        "models.UserDetailsRequest": {
+        "dto.UserDetailsRequest": {
             "type": "object",
             "required": [
                 "city",
@@ -719,6 +755,9 @@
                 "lastName": {
                     "type": "string"
                 },
+                "parentId": {
+                    "type": "string"
+                },
                 "phone": {
                     "type": "string"
                 },
@@ -732,6 +771,35 @@
                     "type": "string"
                 },
                 "zip": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.UserResponse": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "$ref": "#/definitions/dto.AddressOutput"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "firstName": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "parentId": {
+                    "type": "string"
+                },
+                "phone": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,31 +1,20 @@
 definitions:
-  gin.ErrorResponse:
-    description: Standard API error response format
+  dto.AddressOutput:
     properties:
-      message:
-        description: Error message
-        example: Something went wrong
+      city:
         type: string
-      status:
-        description: Always false for errors
-        example: false
-        type: boolean
-    type: object
-  gin.Response:
-    description: Standard API success response format
-    properties:
-      data:
-        description: Optional data payload
-      message:
-        description: Optional success message
-        example: Operation successful
+      country:
         type: string
-      status:
-        description: Indicates success status
-        example: true
-        type: boolean
+      region:
+        type: string
+      street1:
+        type: string
+      street2:
+        type: string
+      zip:
+        type: string
     type: object
-  models.AddCategoryRequest:
+  dto.CategoryRequest:
     properties:
       name:
         maxLength: 50
@@ -39,8 +28,21 @@ definitions:
     - name
     - type
     type: object
-  models.AddDeviceRequest:
+  dto.CategoryResponse:
     properties:
+      id:
+        type: string
+      name:
+        type: string
+      type:
+        type: string
+    type: object
+  dto.DeviceRequest:
+    properties:
+      category:
+        type: string
+      description:
+        type: string
       deviceId:
         maxLength: 50
         minLength: 3
@@ -53,30 +55,46 @@ definitions:
     - deviceId
     - deviceName
     type: object
-  models.AttachIotPolicyRequest:
+  dto.DeviceResponse:
+    properties:
+      category:
+        type: string
+      createdAt:
+        type: string
+      description:
+        type: string
+      deviceId:
+        type: string
+      deviceName:
+        type: string
+    type: object
+  dto.ErrorResponse:
+    properties:
+      code:
+        type: string
+      error:
+        type: string
+      success:
+        type: boolean
+    type: object
+  dto.PolicyAttachRequest:
     properties:
       identityId:
         type: string
     required:
     - identityId
     type: object
-  models.CategoryResponse:
+  dto.Response:
     properties:
-      name:
+      data: {}
+      error:
         type: string
-      type:
+      message:
         type: string
+      success:
+        type: boolean
     type: object
-  models.DeviceResponse:
-    properties:
-      device_name:
-        type: string
-      mac_address:
-        type: string
-      user_id:
-        type: string
-    type: object
-  models.GetDeviceSensorDataRequest:
+  dto.SensorDataRequest:
     properties:
       dateMode:
         enum:
@@ -95,14 +113,7 @@ definitions:
     - deviceMacId
     - timestamp
     type: object
-  models.GetDeviceSensorDataResponse:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/models.SensorData'
-        type: array
-    type: object
-  models.SensorData:
+  dto.SensorDataResponse:
     properties:
       amperage:
         type: string
@@ -113,7 +124,7 @@ definitions:
       timestamp:
         type: integer
     type: object
-  models.UserDetails:
+  dto.UserDetailsRequest:
     properties:
       city:
         type: string
@@ -125,28 +136,7 @@ definitions:
         type: string
       lastName:
         type: string
-      phone:
-        type: string
-      region:
-        type: string
-      street1:
-        type: string
-      street2:
-        type: string
-      zip:
-        type: string
-    type: object
-  models.UserDetailsRequest:
-    properties:
-      city:
-        type: string
-      country:
-        type: string
-      email:
-        type: string
-      firstName:
-        type: string
-      lastName:
+      parentId:
         type: string
       phone:
         type: string
@@ -169,6 +159,25 @@ definitions:
     - street1
     - zip
     type: object
+  dto.UserResponse:
+    properties:
+      address:
+        $ref: '#/definitions/dto.AddressOutput'
+      createdAt:
+        type: string
+      email:
+        type: string
+      firstName:
+        type: string
+      id:
+        type: string
+      lastName:
+        type: string
+      parentId:
+        type: string
+      phone:
+        type: string
+    type: object
 info:
   contact: {}
 paths:
@@ -183,26 +192,26 @@ paths:
         name: category
         required: true
         schema:
-          $ref: '#/definitions/models.AddCategoryRequest'
+          $ref: '#/definitions/dto.CategoryRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Category added successfully
           schema:
-            $ref: '#/definitions/gin.Response'
+            $ref: '#/definitions/dto.Response'
         "400":
           description: Validation error
           schema:
-            $ref: '#/definitions/gin.ErrorResponse'
+            $ref: '#/definitions/dto.ErrorResponse'
         "409":
           description: Category already exists
           schema:
-            $ref: '#/definitions/gin.ErrorResponse'
+            $ref: '#/definitions/dto.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/gin.ErrorResponse'
+            $ref: '#/definitions/dto.ErrorResponse'
       summary: Add a new category
       tags:
       - Category Management
@@ -216,12 +225,12 @@ paths:
           description: List of categories
           schema:
             items:
-              $ref: '#/definitions/models.CategoryResponse'
+              $ref: '#/definitions/dto.CategoryResponse'
             type: array
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/gin.ErrorResponse'
+            $ref: '#/definitions/dto.ErrorResponse'
       summary: Get all categories
       tags:
       - Category Management
@@ -243,12 +252,12 @@ paths:
           description: List of categories
           schema:
             items:
-              $ref: '#/definitions/models.CategoryResponse'
+              $ref: '#/definitions/dto.CategoryResponse'
             type: array
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/gin.ErrorResponse'
+            $ref: '#/definitions/dto.ErrorResponse'
       summary: Get categories by type
       tags:
       - Category Management
@@ -268,26 +277,26 @@ paths:
         name: device
         required: true
         schema:
-          $ref: '#/definitions/models.AddDeviceRequest'
+          $ref: '#/definitions/dto.DeviceRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Device added successfully
           schema:
-            $ref: '#/definitions/gin.Response'
+            $ref: '#/definitions/dto.Response'
         "400":
           description: Validation error
           schema:
-            $ref: '#/definitions/gin.ErrorResponse'
+            $ref: '#/definitions/dto.ErrorResponse'
         "401":
           description: User not authenticated
           schema:
-            $ref: '#/definitions/gin.ErrorResponse'
+            $ref: '#/definitions/dto.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/gin.ErrorResponse'
+            $ref: '#/definitions/dto.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Add a new device
@@ -304,22 +313,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/models.AttachIotPolicyRequest'
+          $ref: '#/definitions/dto.PolicyAttachRequest'
       produces:
       - application/json
       responses:
         "200":
           description: IoT policy attached successfully
           schema:
-            $ref: '#/definitions/gin.Response'
+            $ref: '#/definitions/dto.Response'
         "400":
           description: Invalid request or validation error
           schema:
-            $ref: '#/definitions/gin.ErrorResponse'
+            $ref: '#/definitions/dto.ErrorResponse'
         "500":
           description: Failed to attach IoT policy
           schema:
-            $ref: '#/definitions/gin.ErrorResponse'
+            $ref: '#/definitions/dto.ErrorResponse'
       summary: Attach IoT policy
       tags:
       - Policy Management
@@ -334,22 +343,29 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/models.GetDeviceSensorDataRequest'
+          $ref: '#/definitions/dto.SensorDataRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Sensor data for the device
           schema:
-            $ref: '#/definitions/models.GetDeviceSensorDataResponse'
+            allOf:
+            - $ref: '#/definitions/dto.Response'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/dto.SensorDataResponse'
+                  type: array
+              type: object
         "400":
           description: Invalid request or validation error
           schema:
-            $ref: '#/definitions/gin.ErrorResponse'
+            $ref: '#/definitions/dto.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/gin.ErrorResponse'
+            $ref: '#/definitions/dto.ErrorResponse'
       summary: Get device sensor data
       tags:
       - Device Data
@@ -384,9 +400,13 @@ paths:
               type: string
             type: object
       summary: Check if user has parent ID
+      tags:
+      - User Management
   /user/details:
     get:
-      description: Retrieves the user details for the authenticated user
+      consumes:
+      - application/json
+      description: Retrieve authenticated user's profile information
       parameters:
       - description: User ID
         in: header
@@ -397,66 +417,76 @@ paths:
       - application/json
       responses:
         "200":
-          description: No user details found (null response)
+          description: User details retrieved successfully
           schema:
-            additionalProperties: true
-            type: object
+            allOf:
+            - $ref: '#/definitions/dto.Response'
+            - properties:
+                data:
+                  $ref: '#/definitions/dto.UserResponse'
+              type: object
         "401":
-          description: Error when user is not authenticated
+          description: User not authenticated
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/dto.ErrorResponse'
+        "404":
+          description: User not found
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
         "500":
-          description: Error when retrieving user details fails
+          description: Internal server error
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/dto.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
       summary: Get user details
+      tags:
+      - User Management
     post:
       consumes:
       - application/json
-      description: Updates or adds user details for the authenticated user
+      description: Update the authenticated user's profile information
       parameters:
       - description: User ID
         in: header
         name: X-User-ID
         required: true
         type: string
-      - description: User details information
+      - description: User details
         in: body
-        name: request
+        name: user
         required: true
         schema:
-          $ref: '#/definitions/models.UserDetailsRequest'
+          $ref: '#/definitions/dto.UserDetailsRequest'
       produces:
       - application/json
       responses:
         "200":
           description: User details updated successfully
           schema:
-            additionalProperties: true
-            type: object
+            allOf:
+            - $ref: '#/definitions/dto.Response'
+            - properties:
+                data:
+                  $ref: '#/definitions/dto.UserResponse'
+              type: object
         "400":
-          description: Error when request validation fails
+          description: Validation error
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/dto.ErrorResponse'
         "401":
-          description: Error when user is not authenticated
+          description: User not authenticated
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/dto.ErrorResponse'
         "500":
-          description: Error when updating user details fails
+          description: Internal server error
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/dto.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
       summary: Update user details
+      tags:
+      - User Management
   /user/devices:
     get:
       consumes:
@@ -475,16 +505,16 @@ paths:
           description: List of user devices
           schema:
             items:
-              $ref: '#/definitions/models.DeviceResponse'
+              $ref: '#/definitions/dto.DeviceResponse'
             type: array
         "401":
           description: User not authenticated
           schema:
-            $ref: '#/definitions/gin.ErrorResponse'
+            $ref: '#/definitions/dto.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/gin.ErrorResponse'
+            $ref: '#/definitions/dto.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: List user devices

--- a/internal/domain/entities.go
+++ b/internal/domain/entities.go
@@ -10,8 +10,8 @@ import (
 type User struct {
 	ID        string    `json:"id" db:"user_id"`
 	Email     string    `json:"email" db:"email"`
-	FirstName string    `json:"firstName" db:"first_name"`
-	LastName  string    `json:"lastName" db:"last_name"`
+	FirstName *string   `json:"firstName" db:"first_name"`
+	LastName  *string   `json:"lastName" db:"last_name"`
 	Phone     *string   `json:"phone" db:"phone"`
 	Address   Address   `json:"address"`
 	ParentID  *string   `json:"parentId,omitempty" db:"parent_id"`
@@ -64,8 +64,8 @@ func NewUser(email, firstName, lastName, phone string) *User {
 	return &User{
 		ID:        uuid.New().String(),
 		Email:     email,
-		FirstName: firstName,
-		LastName:  lastName,
+		FirstName: &firstName,
+		LastName:  &lastName,
 		Phone:     &phone,
 		CreatedAt: now,
 		UpdatedAt: now,

--- a/internal/middleware/gin.go
+++ b/internal/middleware/gin.go
@@ -5,14 +5,23 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+
+	"n1h41/zolaris-backend-app/internal/services"
 )
 
 // GinAuthMiddleware checks for user authentication
 // This is a simplified version - in a real app, use JWT or OAuth2
-func GinAuthMiddleware() gin.HandlerFunc {
+func GinAuthMiddleware(userService *services.UserService) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Get user ID from header
-		userID := c.GetHeader("X-User-ID")
+		cogntioId := c.GetHeader("X-User-ID")
+
+		userID, err := userService.GetUserIdByCognitoId(c.Request.Context(), cogntioId)
+		if err != nil {
+			log.Printf("Error retrieving user ID by Cognito ID: %v", err)
+			c.JSON(500, gin.H{"status": false, "message": "Internal server error"})
+			c.Abort()
+			return
+		}
 
 		// For demo purposes only - in production, never use a default user
 		if userID == "" {

--- a/internal/repositories/interfaces.go
+++ b/internal/repositories/interfaces.go
@@ -8,6 +8,7 @@ import (
 
 // UserRepositoryInterface defines the operations for user data
 type UserRepositoryInterface interface {
+	GetUserIdByCognitoId(ctx context.Context, cId string) (string, error)
 	GetUserByID(ctx context.Context, userID string) (*domain.User, error)
 	CreateUser(ctx context.Context, user *domain.User) error
 	UpdateUser(ctx context.Context, user *domain.User) error

--- a/internal/repositories/user_repository.go
+++ b/internal/repositories/user_repository.go
@@ -25,6 +25,21 @@ func NewUserRepository(dbPool *pgxpool.Pool) UserRepositoryInterface {
 	}
 }
 
+func (r *UserRepository) GetUserIdByCognitoId(ctx context.Context, cId string) (string, error) {
+	var userId string
+
+	query := `select user_id from z_users where cognito_id = $1`
+
+	if err := r.db.QueryRow(ctx, query, cId).Scan(&userId); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil // User not found
+		}
+		return "", fmt.Errorf("failed to get user ID by Cognito ID: %w", err)
+	}
+
+	return userId, nil
+}
+
 // GetUserByID retrieves a user by ID from PostgreSQL
 func (r *UserRepository) GetUserByID(ctx context.Context, userID string) (*domain.User, error) {
 	query := `

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -21,6 +21,11 @@ func NewUserService(userRepo repositories.UserRepositoryInterface) *UserService 
 	return &UserService{userRepo: userRepo}
 }
 
+func (s *UserService) GetUserIdByCognitoId(ctx context.Context, cId string) (string, error) {
+	log.Printf("Getting user ID by Cognito ID: %s", cId)
+	return s.userRepo.GetUserIdByCognitoId(ctx, cId)
+}
+
 // GetUserByID retrieves a user by their ID
 func (s *UserService) GetUserByID(ctx context.Context, userID string) (*domain.User, error) {
 	log.Printf("Getting user details for user %s", userID)
@@ -69,4 +74,3 @@ func (s *UserService) UpdateUserDetails(ctx context.Context, userID string, req 
 func (s *UserService) CheckHasParentID(ctx context.Context, userID string) (bool, error) {
 	return s.userRepo.CheckHasParentID(ctx, userID)
 }
-

--- a/internal/transport/dto/responses.go
+++ b/internal/transport/dto/responses.go
@@ -29,8 +29,8 @@ type ValidationError struct {
 type UserResponse struct {
 	ID        string        `json:"id"`
 	Email     string        `json:"email"`
-	FirstName string        `json:"firstName"`
-	LastName  string        `json:"lastName"`
+	FirstName *string       `json:"firstName"`
+	LastName  *string       `json:"lastName"`
 	Phone     *string       `json:"phone"`
 	Address   AddressOutput `json:"address"`
 	ParentID  string        `json:"parentId,omitempty"`

--- a/internal/transport/mappers/mappers.go
+++ b/internal/transport/mappers/mappers.go
@@ -49,8 +49,8 @@ func UserRequestToEntity(req *dto.UserDetailsRequest, existingUser *domain.User)
 	}
 
 	user.Email = req.Email
-	user.FirstName = req.FirstName
-	user.LastName = req.LastName
+	user.FirstName = &req.FirstName
+	user.LastName = &req.LastName
 	user.Phone = &req.Phone
 	user.Address = domain.Address{
 		Street1: req.Street1,

--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ func main() {
 
 	// Group private routes (require authentication)
 	private := r.Group("/")
-	private.Use(middleware.GinAuthMiddleware())
+	private.Use(middleware.GinAuthMiddleware(userService))
 	{
 		private.POST("/device/add", addDeviceHandler.HandleGin)
 		private.GET("/user/devices", listUserDevicesHandler.HandleGin)


### PR DESCRIPTION
This change updates API documentation and implementation to use the dto
package
instead of models for request/response structures. It also enhances the
auth
middleware to fetch user IDs from Cognito IDs and improves user profile
handling.

Changes include:
- Update Swagger docs to reference dto.* instead of models.*
- Add user management tags to API documentation
- Improve response schemas with consistent formatting
- Change FirstName/LastName from string to *string in user domain models
- Implement GetUserIdByCognitoId functionality in user service and
repository
- Update auth middleware to use Cognito ID mapping
- Remove trailing newline in user_handlers.go
