### PR TITLE
feat(docker): add PostgreSQL environment variables to staging configuration

### DIFF
--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -16,6 +16,12 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_REGION=${AWS_REGION}
+      - POSTGRES_HOST=${POSTGRES_HOST}
+      - POSTGRES_PORT=${POSTGRES_PORT}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB_NAME=${POSTGRES_DB_NAME}
+      - POSTGRES_SSL_MODE=${POSTGRES_SSL_MODE}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]


### PR DESCRIPTION
Add required PostgreSQL connection environment variables to the staging
Docker
Compose configuration, allowing the service to connect to a PostgreSQL
database
using environment-specific credentials.
